### PR TITLE
Error if pkgbase is declared incorrectly

### DIFF
--- a/srcinfo/parse.py
+++ b/srcinfo/parse.py
@@ -92,6 +92,12 @@ def parse_srcinfo(source):
         if not key:
             continue
 
+        if key == "pkgbase" and (key in srcinfo or info != srcinfo):
+            errors.append({
+                'line': index,
+                'error': "pkgbase declared more than once or after pkgname"
+            })
+
         if is_array(key):
             list_insert(info, key, value)
         else:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -51,6 +51,30 @@ pkgname = pinkiepie'''
 
 
 
+def test_multiple_pkgbase():
+    from srcinfo.parse import parse_srcinfo
+
+    srcinfo = '''pkgbase = pony
+    pkgdesc = Some description
+    pkgver = 1.0.0
+    pkgrel = 1
+    url = https://example.com
+    arch = i686
+    arch = x86_64
+    license = ISC
+    source = git+https://example.com/package.git
+    md5sums = SKIP
+
+pkgname = luna
+
+pkgbase = ponies'''
+
+    (parsed, errors) = parse_srcinfo(srcinfo)
+    assert package_names_equal(parsed, ['luna'])
+    assert len(errors) == 1
+
+
+
 def test_coverage():
     from srcinfo.utils import get_variable
     from srcinfo.parse import parse_srcinfo


### PR DESCRIPTION
The parser will now generate an error if pkgbase is declared more than
once or if pkgbase is declared inside of a split package.