### PR TITLE
Use builtin unittest library instead of nose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ setup(
     author_email = 'johannes@kyriasis.com',
 
     install_requires = ['parse'],
-    tests_require = ['nose'],
-    test_suite = 'nose.collector',
 
     entry_points = {
         'console_scripts': [

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,11 +1,15 @@
-def package_names_equal(srcinfo, package_names):
-    return set(srcinfo['packages'].keys()) == set(package_names)
+import unittest
+
+class TestSrcinfo(unittest.TestCase):
+
+    def assertPackageNamesEqual(self, srcinfo, package_names):
+        self.assertCountEqual(srcinfo['packages'].keys(), package_names)
 
 
-def test_simple_parse():
-    from srcinfo.parse import parse_srcinfo
+    def testSimpleParse(self):
+        from srcinfo.parse import parse_srcinfo
 
-    srcinfo = '''pkgbase = ponies
+        srcinfo = '''pkgbase = ponies
     pkgdesc = Some description
     pkgver = 1.0.0
     pkgrel = 1
@@ -18,17 +22,16 @@ def test_simple_parse():
 
 pkgname = ponies'''
 
-    (parsed, errors) = parse_srcinfo(srcinfo)
-    assert parsed
-    assert errors == []
-    assert package_names_equal(parsed, ['ponies'])
+        (parsed, errors) = parse_srcinfo(srcinfo)
+        self.assertTrue(parsed)
+        self.assertEqual(errors, [])
+        self.assertPackageNamesEqual(parsed, ['ponies'])
 
 
+    def testSplitPackageNames(self):
+        from srcinfo.parse import parse_srcinfo
 
-def test_split_package_names():
-    from srcinfo.parse import parse_srcinfo
-
-    srcinfo = '''pkgbase = pony
+        srcinfo = '''pkgbase = pony
     pkgdesc = Some description
     pkgver = 1.0.0
     pkgrel = 1
@@ -45,16 +48,15 @@ pkgname = rainbowdash
 
 pkgname = pinkiepie'''
 
-    (parsed, errors) = parse_srcinfo(srcinfo)
-    assert errors == []
-    assert package_names_equal(parsed, ['applejack', 'rainbowdash', 'pinkiepie'])
+        (parsed, errors) = parse_srcinfo(srcinfo)
+        self.assertEqual(errors, [])
+        self.assertPackageNamesEqual(parsed, ['applejack', 'rainbowdash', 'pinkiepie'])
 
 
+    def testRejectsMultiplePkgbase(self):
+        from srcinfo.parse import parse_srcinfo
 
-def test_multiple_pkgbase():
-    from srcinfo.parse import parse_srcinfo
-
-    srcinfo = '''pkgbase = pony
+        srcinfo = '''pkgbase = pony
     pkgdesc = Some description
     pkgver = 1.0.0
     pkgrel = 1
@@ -69,17 +71,17 @@ pkgname = luna
 
 pkgbase = ponies'''
 
-    (parsed, errors) = parse_srcinfo(srcinfo)
-    assert package_names_equal(parsed, ['luna'])
-    assert len(errors) == 1
+        (parsed, errors) = parse_srcinfo(srcinfo)
+        self.assertPackageNamesEqual(parsed, ['luna'])
+        self.assertEqual(len(errors), 1)
+        self.assertIn('pkgbase declared more than once', errors[0]['error'])
 
 
+    def testCoverage(self):
+        from srcinfo.parse import parse_srcinfo
+        from srcinfo.utils import get_variable
 
-def test_coverage():
-    from srcinfo.utils import get_variable
-    from srcinfo.parse import parse_srcinfo
-
-    srcinfo = '''pkgbase = gcc
+        srcinfo = '''pkgbase = gcc
     pkgdesc = The GNU Compiler Collection
     pkgver = 4.9.1
     pkgrel = 2
@@ -148,68 +150,70 @@ pkgname = gcc-go
     options = staticlibs
     options = !emptydirs'''
 
-    expected_packages = ['gcc', 'gcc-libs', 'gcc-fortran', 'gcc-objc', 'gcc-ada', 'gcc-go']
+        expected_packages = ['gcc', 'gcc-libs', 'gcc-fortran', 'gcc-objc', 'gcc-ada', 'gcc-go']
 
-    (parsed, errors) = parse_srcinfo(srcinfo)
-    assert errors == []
-    assert package_names_equal(parsed, expected_packages)
+        (parsed, errors) = parse_srcinfo(srcinfo)
+        self.assertEqual(errors, [])
+        self.assertPackageNamesEqual(parsed, expected_packages)
 
-    for pkgname in expected_packages:
-        assert get_variable('pkgver', pkgname, parsed) == '4.9.1'
-        assert get_variable('pkgrel', pkgname, parsed) == '2'
-        assert get_variable('arch', pkgname, parsed) == ['i686', 'x86_64']
-        assert get_variable('license', pkgname, parsed) == ['GPL', 'LGPL', 'FDL', 'custom']
-        assert get_variable('url', pkgname, parsed) == 'http://gcc.gnu.org'
-        assert get_variable('makedepends', pkgname, parsed) == ['binutils>=2.24','libmpc', 'cloog', 'gcc-ada', 'doxygen']
-        assert get_variable('checkdepends', pkgname, parsed) == ['dejagnu', 'inetutils']
-        assert get_variable('source', pkgname, parsed) == ['ftp://gcc.gnu.org/pub/gcc/snapshots/4.9-20140903/gcc-4.9-20140903.tar.bz2',
-                                                           'gcc-4.8-filename-output.patch',
-                                                           'gcc-4.9-isl-0.13-hack.patch']
-        assert get_variable('md5sums', pkgname, parsed) == ['24dfd67139fda4746d2deff18182611d',
-                                                            '40cb437805e2f7a006aa0d0c3098ab0f',
-                                                            'f26ae06b9cbc8abe86f5ee4dc5737da8']
+        for pkgname in expected_packages:
+            self.assertEqual(get_variable('pkgver', pkgname, parsed), '4.9.1')
+            self.assertEqual(get_variable('pkgrel', pkgname, parsed), '2')
+            self.assertEqual(get_variable('arch', pkgname, parsed), ['i686', 'x86_64'])
+            self.assertEqual(get_variable('license', pkgname, parsed), ['GPL', 'LGPL', 'FDL', 'custom'])
+            self.assertEqual(get_variable('url', pkgname, parsed), 'http://gcc.gnu.org')
+            self.assertEqual(get_variable('makedepends', pkgname, parsed), ['binutils>=2.24','libmpc', 'cloog', 'gcc-ada', 'doxygen'])
+            self.assertEqual(get_variable('checkdepends', pkgname, parsed), ['dejagnu', 'inetutils'])
+            self.assertEqual(get_variable('source', pkgname, parsed), [
+                'ftp://gcc.gnu.org/pub/gcc/snapshots/4.9-20140903/gcc-4.9-20140903.tar.bz2',
+                'gcc-4.8-filename-output.patch',
+                'gcc-4.9-isl-0.13-hack.patch'])
+            self.assertEqual(get_variable('md5sums', pkgname, parsed), [
+                '24dfd67139fda4746d2deff18182611d',
+                '40cb437805e2f7a006aa0d0c3098ab0f',
+                'f26ae06b9cbc8abe86f5ee4dc5737da8'])
 
-    assert get_variable('pkgdesc', 'gcc-libs', parsed) == 'Runtime libraries shipped by GCC'
-    assert get_variable('groups', 'gcc-libs', parsed) == ['base']
-    assert get_variable('depends', 'gcc-libs', parsed) == ['glibc>=2.20']
-    assert get_variable('options', 'gcc-libs', parsed) == ['!emptydirs', '!strip']
-    assert get_variable('install', 'gcc-libs', parsed) == 'gcc-libs.install'
+        self.assertEqual(get_variable('pkgdesc', 'gcc-libs', parsed), 'Runtime libraries shipped by GCC')
+        self.assertEqual(get_variable('groups', 'gcc-libs', parsed), ['base'])
+        self.assertEqual(get_variable('depends', 'gcc-libs', parsed), ['glibc>=2.20'])
+        self.assertEqual(get_variable('options', 'gcc-libs', parsed), ['!emptydirs', '!strip'])
+        self.assertEqual(get_variable('install', 'gcc-libs', parsed), 'gcc-libs.install')
 
-    assert get_variable('pkgdesc', 'gcc', parsed) == 'The GNU Compiler Collection - C and C++ frontends'
-    assert get_variable('depends', 'gcc', parsed) == ['gcc-libs=4.9.1-2', 'binutils>=2.24', 'libmpc', 'cloog']
-    assert get_variable('groups', 'gcc', parsed) == ['base-devel']
-    assert get_variable('options', 'gcc', parsed) == ['staticlibs']
-    assert get_variable('install', 'gcc', parsed) == 'gcc.install'
+        self.assertEqual(get_variable('pkgdesc', 'gcc', parsed), 'The GNU Compiler Collection - C and C++ frontends')
+        self.assertEqual(get_variable('depends', 'gcc', parsed), ['gcc-libs=4.9.1-2', 'binutils>=2.24', 'libmpc', 'cloog'])
+        self.assertEqual(get_variable('groups', 'gcc', parsed), ['base-devel'])
+        self.assertEqual(get_variable('options', 'gcc', parsed), ['staticlibs'])
+        self.assertEqual(get_variable('install', 'gcc', parsed), 'gcc.install')
 
-    assert get_variable('pkgdesc', 'gcc-fortran', parsed) == 'Fortran front-end for GCC'
-    assert get_variable('depends', 'gcc-fortran', parsed) == ['gcc=4.9.1-2']
-    assert get_variable('options', 'gcc-fortran', parsed) == ['staticlibs', '!emptydirs']
-    assert get_variable('install', 'gcc-fortran', parsed) == 'gcc-fortran.install'
-    assert not get_variable('groups', 'gcc-fortran', parsed)
+        self.assertEqual(get_variable('pkgdesc', 'gcc-fortran', parsed), 'Fortran front-end for GCC')
+        self.assertEqual(get_variable('depends', 'gcc-fortran', parsed), ['gcc=4.9.1-2'])
+        self.assertEqual(get_variable('options', 'gcc-fortran', parsed), ['staticlibs', '!emptydirs'])
+        self.assertEqual(get_variable('install', 'gcc-fortran', parsed), 'gcc-fortran.install')
+        self.assertFalse(get_variable('groups', 'gcc-fortran', parsed))
 
-    assert get_variable('pkgdesc', 'gcc-objc', parsed) == 'Objective-C front-end for GCC'
-    assert get_variable('depends', 'gcc-objc', parsed) == ['gcc=4.9.1-2']
-    assert get_variable('options', 'gcc-objc', parsed) == ['!emptydirs']
-    assert not get_variable('install', 'gcc-objc', parsed)
-    assert not get_variable('groups', 'gcc-objc', parsed)
+        self.assertEqual(get_variable('pkgdesc', 'gcc-objc', parsed), 'Objective-C front-end for GCC')
+        self.assertEqual(get_variable('depends', 'gcc-objc', parsed), ['gcc=4.9.1-2'])
+        self.assertEqual(get_variable('options', 'gcc-objc', parsed), ['!emptydirs'])
+        self.assertFalse(get_variable('install', 'gcc-objc', parsed))
+        self.assertFalse(get_variable('groups', 'gcc-objc', parsed))
 
-    assert get_variable('pkgdesc', 'gcc-ada', parsed) == 'Ada front-end for GCC (GNAT)'
-    assert get_variable('depends', 'gcc-ada', parsed) == ['gcc=4.9.1-2']
-    assert get_variable('options', 'gcc-ada', parsed) == ['staticlibs', '!emptydirs']
-    assert get_variable('install', 'gcc-ada', parsed) == 'gcc-ada.install'
-    assert not get_variable('groups', 'gcc-ada', parsed)
+        self.assertEqual(get_variable('pkgdesc', 'gcc-ada', parsed), 'Ada front-end for GCC (GNAT)')
+        self.assertEqual(get_variable('depends', 'gcc-ada', parsed), ['gcc=4.9.1-2'])
+        self.assertEqual(get_variable('options', 'gcc-ada', parsed), ['staticlibs', '!emptydirs'])
+        self.assertEqual(get_variable('install', 'gcc-ada', parsed), 'gcc-ada.install')
+        self.assertFalse(get_variable('groups', 'gcc-ada', parsed))
 
-    assert get_variable('pkgdesc', 'gcc-go', parsed) == 'Go front-end for GCC'
-    assert get_variable('depends', 'gcc-go', parsed) == ['gcc=4.9.1-2']
-    assert get_variable('options', 'gcc-go', parsed) == ['staticlibs', '!emptydirs']
-    assert get_variable('install', 'gcc-go', parsed) == 'gcc-go.install'
-    assert not get_variable('groups', 'gcc-go', parsed)
+        self.assertEqual(get_variable('pkgdesc', 'gcc-go', parsed), 'Go front-end for GCC')
+        self.assertEqual(get_variable('depends', 'gcc-go', parsed), ['gcc=4.9.1-2'])
+        self.assertEqual(get_variable('options', 'gcc-go', parsed), ['staticlibs', '!emptydirs'])
+        self.assertEqual(get_variable('install', 'gcc-go', parsed), 'gcc-go.install')
+        self.assertFalse(get_variable('groups', 'gcc-go', parsed))
 
-def test_empty_attr_in_package_overrides_global():
-    from srcinfo.parse import parse_srcinfo
-    from srcinfo.utils import get_variable
+    def testEmptyAttrInPackageOverridesGlobal(self):
+        from srcinfo.parse import parse_srcinfo
+        from srcinfo.utils import get_variable
 
-    srcinfo = '''pkgbase = pony
+        srcinfo = '''pkgbase = pony
     depends = global
 
 pkgname = applejack
@@ -218,7 +222,11 @@ pkgname = pinkiepie
     depends =
 '''
 
-    (parsed, errors) = parse_srcinfo(srcinfo)
-    assert errors == [], errors
-    assert get_variable('depends', 'pinkiepie', parsed) == [], get_variable('depends', 'pinkiepie', parsed)
-    assert get_variable('depends', 'applejack', parsed) == ['global']
+        (parsed, errors) = parse_srcinfo(srcinfo)
+        self.assertEqual(errors, [])
+        self.assertCountEqual(get_variable('depends', 'pinkiepie', parsed), [])
+        self.assertCountEqual(get_variable('depends', 'applejack', parsed), ['global'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Multiple reasons:

1) Nose is unmaintained and destined for the scrapyard, according to its
own homepage.
2) unittests's assert functions provide nice abstractions and better
error messages on failure (e.g. explains *why* the failure happened, not
just that it happened).